### PR TITLE
Add support for Lite API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: swift-actions/setup-swift@v2
+      with:
+        swift-version: "6.1.0"
+
     - name: Cache Swift Package Manager
       uses: actions/cache@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,6 @@ jobs:
         key: spm-${{ hashFiles('**/Package.resolved') }}
         restore-keys: spm-
 
-    - name: Resolve dependencies
-      run: swift package resolve
-
-    - name: Build
-      run: swift build --verbose
-
     - name: Test
       run: swift test --verbose
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache Swift Package Manager
+      uses: actions/cache@v3
+      with:
+        path: |
+          .build
+          ~/.cache/org.swift.swiftpm
+        key: spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: spm-
+
+    - name: Resolve dependencies
+      run: swift package resolve
+
+    - name: Build
+      run: swift build --verbose
+
+    - name: Test
+      run: swift test --verbose
+      env:
+        IPInfoKitAccessToken: ${{ secrets.IPINFO_TOKEN }}

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ipinfoKit.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ipinfoKit.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ipinfoKit"
+               BuildableName = "ipinfoKit"
+               BlueprintName = "ipinfoKit"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ipinfoKitTests"
+               BuildableName = "ipinfoKitTests"
+               BlueprintName = "ipinfoKitTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "IPInfoKitAccessToken"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ipinfoKit"
+            BuildableName = "ipinfoKit"
+            BlueprintName = "ipinfoKit"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/ipinfoKit.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ipinfoKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "1640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -55,7 +55,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "IPInfoKitAccessToken"
-            value = ""
+            value = "17025cdd34b7a7"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,6 @@ let package = Package(
             .testTarget(
                 name: "ipinfoKitTests",
                 dependencies: ["ipinfoKit"],
-                path: "Tests",
-                sources: [
-                    "ipinfoKitTests/ipinfoKitTests.swift",
-                ]),
+                path: "Tests"
+              ),
     ])

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ IPINFO.shared.getDetails(ip: "8.8.8.8") { status, response, msg in
 }
 ```
 
+# Contributing
+
+## Running the tests
+
+Some tests require a [token](https://ipinfo.io/dashboard/token) to pass. You can add yours as an [environment variable of the scheme](https://developer.apple.com/documentation/xcode/customizing-the-build-schemes-for-a-project/#Specify-launch-arguments-and-environment-variables).  
+
 # Other Libraries
 
 There are official [IPinfo client libraries](https://ipinfo.io/developers/libraries) available for many languages including PHP, Python, Go, Java, Ruby, and many popular frameworks such as Django, Rails, and Laravel. There are also many third-party libraries and integrations available for our API.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,36 @@ IPINFO.shared.getDetails(ip: "8.8.8.8") { status, response, msg in
 }
 ```
 
+# Lite API
+
+The library gives the possibility to use the [Lite API](https://ipinfo.io/developers/lite-api) too, authentication with your token is still required.
+
+The returned details are slightly different from the Core API.
+
+```swift
+let client = IPInfoLite(token: "YOUR TOKEN")
+let response = try await client.lookup(ip: "1.1.1.1")
+
+switch response {
+case .bogon(let bogon):
+  print(bogon.ip) // 192.168.2.1
+case .ip(let ip):
+  print(ip)
+  /*
+    IPInfoLite.IPResponse(
+      ip: "1.1.1.1",
+      asn: "AS13335",
+      asName: "Cloudflare, Inc.",
+      asDomain: "cloudflare.com",
+      countryCode: "AU",
+      country: "Australia",
+      continentCode: "OC",
+      continent: "Oceania"
+    )
+  */
+}
+```
+
 # Contributing
 
 ## Running the tests

--- a/Sources/ipinfoKit/API/API.swift
+++ b/Sources/ipinfoKit/API/API.swift
@@ -18,6 +18,7 @@ extension Service {
 }
 
 extension Service.Router {
+    @MainActor
     var endPoint: String {
         switch self {
         case .geoLocation(let ipAddress):
@@ -32,6 +33,7 @@ extension Service.Router {
 
 // MARK: - Service
 
+@MainActor
 class Service {
     
     // MARK: Lifecycle
@@ -47,6 +49,7 @@ class Service {
         "Authorization": "Bearer \(Constants.ACCESS_TOKEN)",
     ]
     
+    @MainActor
     func requestAPI(
         URL: Service.Router,
         method: HTTPMethod,
@@ -55,12 +58,14 @@ class Service {
             
             AF.request(URL.endPoint , method: method, parameters: params , encoding: JSONEncoding.default, headers: headers)
                 .response { response in
-                    switch response.result {
-                    case .success(let value):
-                        completion(.success, value ?? Data(), "Success")
-                    case .failure(let err):
-                        completion(.failure, Data(), err.localizedDescription)
-                        break
+                    DispatchQueue.main.async {
+                        switch response.result {
+                        case .success(let value):
+                            completion(.success, value ?? Data(), "Success")
+                        case .failure(let err):
+                            completion(.failure, Data(), err.localizedDescription)
+                            break
+                        }
                     }
                 }
         }

--- a/Sources/ipinfoKit/Cache/Cache.swift
+++ b/Sources/ipinfoKit/Cache/Cache.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@MainActor
 class CachingManager {
     
     // MARK: Lifecycle

--- a/Sources/ipinfoKit/Cache/Cache.swift
+++ b/Sources/ipinfoKit/Cache/Cache.swift
@@ -1,11 +1,4 @@
-//
-//  File.swift
-//
-//
-//
-
 import Foundation
-import UIKit
 
 class CachingManager {
     

--- a/Sources/ipinfoKit/Constant.swift
+++ b/Sources/ipinfoKit/Constant.swift
@@ -1,11 +1,4 @@
-//
-//  File.swift
-//
-//
-//
-
 import Foundation
-import UIKit
 
 public let emptyString = ""
 

--- a/Sources/ipinfoKit/Constant.swift
+++ b/Sources/ipinfoKit/Constant.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-public let emptyString = ""
-
 // MARK: - Constants
 
 open class Constants {
@@ -10,15 +8,15 @@ open class Constants {
     
     /// Getting Application Version from info.plist
     static var APP_VERSION: String {
-        Bundle.main.appVersion ?? emptyString
+        Bundle.main.appVersion ?? ""
     }
     
     static var APP_NAME: String {
-        Bundle.main.appName ?? emptyString
+        Bundle.main.appName ?? ""
     }
     
     static var ACCESS_TOKEN: String {
-        Bundle.main.accessToken ?? emptyString
+      Bundle.main.accessToken ?? ProcessInfo.processInfo.environment["IPInfoKitAccessToken"] ?? ""
     }
     
 }

--- a/Sources/ipinfoKit/Constant.swift
+++ b/Sources/ipinfoKit/Constant.swift
@@ -2,6 +2,7 @@ import Foundation
 
 // MARK: - Constants
 
+@MainActor
 open class Constants {
     
     static let shared = Constants()

--- a/Sources/ipinfoKit/CountryData/CountryData.swift
+++ b/Sources/ipinfoKit/CountryData/CountryData.swift
@@ -8,7 +8,7 @@ import Foundation
 
 // MARK: - CountryFlag
 
-public struct CountryFlag: Codable {
+public struct CountryFlag: Codable, Sendable {
     let emoji: String
     let unicode: String
     
@@ -19,8 +19,7 @@ public struct CountryFlag: Codable {
 }
 
 // MARK: - CountryCurrency
-
-public struct CountryCurrency: Codable {
+public struct CountryCurrency: Codable, Sendable {
     let code: String
     let symbol: String
     
@@ -31,8 +30,7 @@ public struct CountryCurrency: Codable {
 }
 
 // MARK: - CountryContinent
-
-public struct CountryContinent: Codable {
+public struct CountryContinent: Codable, Sendable {
     let code: String
     let name: String
     
@@ -43,8 +41,13 @@ public struct CountryContinent: Codable {
 }
 
 // MARK: - CountryData
-
-public class CountryData: Codable {
+public struct CountryData: Codable, Sendable {
+    
+    // MARK: Lifecycle
+    
+    public init() {
+        self.countryFlagURL = "https://cdn.ipinfo.io/static/images/countries-flags/"
+    }
     
     // MARK: Public
     
@@ -52,6 +55,7 @@ public class CountryData: Codable {
         CountryData.countryMap[countryCode] ?? ""
     }
     
+    @MainActor
     public func getCountryFlag(_ countryCode: String) -> CountryFlag {
         CountryData.countriesFlags[countryCode] ?? CountryFlag(emoji: "", unicode: "")
     }
@@ -60,10 +64,12 @@ public class CountryData: Codable {
         countryFlagURL + countryCode + ".svg"
     }
     
+    @MainActor
     public func getCountryCurrency(_ countryCode: String) -> CountryCurrency {
         CountryData.countriesCurrencies[countryCode] ?? CountryCurrency(code: "", symbol: "")
     }
     
+    @MainActor
     public func getContinent(_ countryCode: String) -> CountryContinent {
         CountryData.continents[countryCode] ?? CountryContinent(code: "", name: "")
     }
@@ -333,6 +339,7 @@ public class CountryData: Codable {
         "RO", "BG", "BE",
     ]
     
+    @MainActor
     static let countriesFlags: [String: CountryFlag] = [
         "AD": CountryFlag(emoji: "🇦🇩", unicode: "U+1F1E6 U+1F1E9"),
         "AE": CountryFlag(emoji: "🇦🇪", unicode: "U+1F1E6 U+1F1EA"),
@@ -585,6 +592,7 @@ public class CountryData: Codable {
         "ZM": CountryFlag(emoji: "🇿🇲", unicode: "U+1F1FF U+1F1F2"),
         "ZW": CountryFlag(emoji: "🇿🇼", unicode: "U+1F1FF U+1F1FC"),
     ]
+    @MainActor
     static let countriesCurrencies: [String: CountryCurrency] = [
         "AD": CountryCurrency(code: "EUR", symbol: "€"),
         "AE": CountryCurrency(code: "AED", symbol: "د.إ"),
@@ -838,6 +846,7 @@ public class CountryData: Codable {
         "ZW": CountryCurrency(code: "ZWL", symbol: "Z$"),
     ]
     
+    @MainActor
     static let continents: [String: CountryContinent] = [
         
         "BD": CountryContinent(code: "AS", name: "Asia"),
@@ -1092,5 +1101,5 @@ public class CountryData: Codable {
         "MZ": CountryContinent(code: "AF", name: "Africa"),
     ]
     
-    final var countryFlagURL = "https://cdn.ipinfo.io/static/images/countries-flags/"
+    let countryFlagURL: String
 }

--- a/Sources/ipinfoKit/GeoLocation/GeoLocation.swift
+++ b/Sources/ipinfoKit/GeoLocation/GeoLocation.swift
@@ -21,7 +21,9 @@ extension IPINFO {
                     switch status {
                     case .success:
                         do {
-                            let response = try JSONDecoder().decode(IPResponse.self, from: data)
+                            var decoder = JSONDecoder()
+                            decoder.keyDecodingStrategy = .convertFromSnakeCase
+                            let response = try decoder.decode(IPResponse.self, from: data)
                             if response.bogon ?? false {
                                 completion(.failure, nil, "IP is Bogon")
                             } else {

--- a/Sources/ipinfoKit/IPInfoLite.swift
+++ b/Sources/ipinfoKit/IPInfoLite.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 @available(iOS 13.0.0, macOS 10.15.0, *)
+@MainActor
 open class IPInfoLite {
   private let urlSession: URLSession
   private let jsonDecoder: JSONDecoder = {

--- a/Sources/ipinfoKit/IPInfoLite.swift
+++ b/Sources/ipinfoKit/IPInfoLite.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+@available(iOS 13.0.0, macOS 10.15.0, *)
+open class IPInfoLite {
+  private let urlSession: URLSession
+  private let jsonDecoder: JSONDecoder = {
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    return decoder
+  }()
+
+  private var token: String
+
+  public init(token: String, urlSession: URLSession = .shared) {
+    self.token = token
+    self.urlSession = urlSession
+  }
+
+  public func lookup(ip: String) async throws -> Response {
+    var urlRequest = URLRequest(url: URL(string: "https://api.ipinfo.io/lite/\(ip)")!)
+    urlRequest.allHTTPHeaderFields = [
+      "accept": "application/json",
+      "authorization": "Bearer \(token)",
+      "content-type": "application/json",
+    ]
+
+    let (data, response) = try await urlSession.data(for: urlRequest)
+
+    let httpResponse = response as! HTTPURLResponse
+    guard (200..<300).contains(httpResponse.statusCode) else {
+      throw IPInfoLite.Error.unacceptableStatusCode(httpResponse.statusCode)
+    }
+
+    return try jsonDecoder.decode(Response.self, from: data)
+  }
+}
+
+@available(iOS 13.0.0, macOS 10.15.0, *)
+extension IPInfoLite {
+  public struct Response: Equatable, Decodable {
+    public let ip: String
+    public let asn: String
+    public let asName: String
+    public let asDomain: String
+    public let countryCode: String
+    public let country: String
+    public let continentCode: String
+    public let continent: String
+
+    public init(
+      ip: String,
+      asn: String,
+      asName: String,
+      asDomain: String,
+      countryCode: String,
+      country: String,
+      continentCode: String,
+      continent: String
+    ) {
+      self.ip = ip
+      self.asn = asn
+      self.asName = asName
+      self.asDomain = asDomain
+      self.countryCode = countryCode
+      self.country = country
+      self.continentCode = continentCode
+      self.continent = continent
+    }
+  }
+}
+
+@available(iOS 13.0.0, macOS 10.15.0, *)
+extension IPInfoLite {
+  public enum Error: Swift.Error, LocalizedError {
+    case unacceptableStatusCode(Int)
+
+    public var errorDescription: String? {
+      switch self {
+      case .unacceptableStatusCode(let statusCode):
+        return "Response status code was unacceptable: \(statusCode)."
+      }
+    }
+  }
+}

--- a/Sources/ipinfoKit/IPInfoLite.swift
+++ b/Sources/ipinfoKit/IPInfoLite.swift
@@ -37,7 +37,35 @@ open class IPInfoLite {
 
 @available(iOS 13.0.0, macOS 10.15.0, *)
 extension IPInfoLite {
-  public struct Response: Equatable, Decodable {
+  public enum Response: Equatable, Decodable {
+    private enum CodingKeys: CodingKey {
+      case bogon
+    }
+
+    case ip(IPResponse)
+    case bogon(BogonResponse)
+
+    public init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      let isBogon = try container.decodeIfPresent(Bool.self, forKey: .bogon) ?? false
+
+      if isBogon {
+        self = .bogon(try BogonResponse(from: decoder))
+      } else {
+        self = .ip(try IPResponse(from: decoder))
+      }
+    }
+  }
+
+  public struct BogonResponse: Equatable, Decodable {
+    public let ip: String
+
+    public init(ip: String) {
+      self.ip = ip
+    }
+  }
+
+  public struct IPResponse: Equatable, Decodable {
     public let ip: String
     public let asn: String
     public let asName: String

--- a/Sources/ipinfoKit/Model/ASN/ASN + Model.swift
+++ b/Sources/ipinfoKit/Model/ASN/ASN + Model.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-public class ASN: Codable {
+public struct ASN: Codable, Sendable {
     
     // MARK: Lifecycle
     

--- a/Sources/ipinfoKit/Model/ASNResponse/ASNResponse.swift
+++ b/Sources/ipinfoKit/Model/ASNResponse/ASNResponse.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public struct ASNResponse: Codable {
+public struct ASNResponse: Codable, Sendable {
     
     // MARK: Lifecycle
     

--- a/Sources/ipinfoKit/Model/Abuse/Abuse.swift
+++ b/Sources/ipinfoKit/Model/Abuse/Abuse.swift
@@ -5,7 +5,8 @@
 //
 
 import Foundation
-public class Abuse: Codable {
+
+public struct Abuse: Codable, Sendable {
     
     // MARK: Lifecycle
     

--- a/Sources/ipinfoKit/Model/Carrier/Carrier.swift
+++ b/Sources/ipinfoKit/Model/Carrier/Carrier.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-public class Carrier: Codable {
+public struct Carrier: Codable, Sendable {
     
     // MARK: Lifecycle
     

--- a/Sources/ipinfoKit/Model/Company/Company.swift
+++ b/Sources/ipinfoKit/Model/Company/Company.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-public class Company: Codable {
+public struct Company: Codable, Sendable {
     
     // MARK: Lifecycle
     

--- a/Sources/ipinfoKit/Model/Continent/Continent.swift
+++ b/Sources/ipinfoKit/Model/Continent/Continent.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-public class Continent: Codable {
+public struct Continent: Codable, Sendable {
     
     // MARK: Lifecycle
     

--- a/Sources/ipinfoKit/Model/Domains/Domains.swift
+++ b/Sources/ipinfoKit/Model/Domains/Domains.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-public class Domains: Codable {
+public struct Domains: Codable, Sendable {
     
     // MARK: Lifecycle
     

--- a/Sources/ipinfoKit/Model/IPResponse/IPResponse.swift
+++ b/Sources/ipinfoKit/Model/IPResponse/IPResponse.swift
@@ -7,122 +7,170 @@
 import Foundation
 
 public struct IPResponse: Codable, Sendable {
-    
-    // MARK: Lifecycle
-    
-    init(
-        ip: String,
-        hostname: String?,
-        bogon: Bool,
-        anycast: Bool,
-        city: String?,
-        region: String?,
-        country: String?,
-        loc: String?,
-        org: String?,
-        postal: String?,
-        timezone: String?,
-        asn: ASN?,
-        company: Company?,
-        carrier: Carrier?,
-        privacy: Privacy?,
-        abuse: Abuse?,
-        domains: Domains?) {
-            self.ip = ip
-            self.hostname = hostname
-            self.bogon = bogon
-            self.anycast = anycast
-            self.city = city
-            self.region = region
-            self.country = country
-            self.loc = loc
-            self.org = org
-            self.postal = postal
-            self.timezone = timezone
-            self.asn = asn
-            self.company = company
-            self.carrier = carrier
-            self.privacy = privacy
-            self.abuse = abuse
-            self.domains = domains
-        }
-    
-    // MARK: Public
-    
-    public var getCountryName: String? {
-        context.getCountryName(country ?? "")
+
+  // MARK: Lifecycle
+
+  init(
+    ip: String,
+    hostname: String?,
+    bogon: Bool,
+    anycast: Bool,
+    city: String?,
+    region: String?,
+    country: String?,
+    loc: String?,
+    org: String?,
+    postal: String?,
+    timezone: String?,
+    asn: ASN?,
+    company: Company?,
+    carrier: Carrier?,
+    privacy: Privacy?,
+    abuse: Abuse?,
+    domains: Domains?) {
+      self.ip = ip
+      self.hostname = hostname
+      self.bogon = bogon
+      self.anycast = anycast
+      self.city = city
+      self.region = region
+      self.country = country
+      self.loc = loc
+      self.org = org
+      self.postal = postal
+      self.timezone = timezone
+      self.asn = asn
+      self.company = company
+      self.carrier = carrier
+      self.privacy = privacy
+      self.abuse = abuse
+      self.domains = domains
     }
-    
-    public var isEU: Bool? {
-        context.isEU(country ?? "")
-    }
-    
-    @MainActor
-    public var getCountryFlag: CountryFlag? {
-        context.getCountryFlag(country ?? "")
-    }
-    
-    public var getCountryFlagURL: String? {
-        context.getCountryFlagURL(country ?? "")
-    }
-    
-    @MainActor
-    public var getCountryCurrency: CountryCurrency? {
-        context.getCountryCurrency(country ?? "")
-    }
-    
-    @MainActor
-    public var getContinent: CountryContinent? {
-        context.getContinent(country ?? "")
-    }
-    
-    public var getLatitude: String? {
-        loc?.components(separatedBy: ",")[safe: 0]
-    }
-    
-    public var getLongitude: String? {
-        loc?.components(separatedBy: ",")[safe: 1]
-    }
-    
-    // MARK: Internal
-    
-    enum CodingKeys: String, CodingKey {
-        case ip
-        case hostname
-        case bogon
-        case anycast
-        case city
-        case region
-        case country
-        case loc
-        case org
-        case postal
-        case timezone
-        case asn
-        case company
-        case carrier
-        case privacy
-        case abuse
-        case domains
-    }
-    
-    let ip: String?
-    let hostname: String?
-    let bogon: Bool?
-    let anycast: Bool?
-    let city: String?
-    let region: String?
-    let country: String?
-    let loc: String?
-    let org: String?
-    let postal: String?
-    let timezone: String?
-    let asn: ASN?
-    let company: Company?
-    let carrier: Carrier?
-    let privacy: Privacy?
-    let abuse: Abuse?
-    let domains: Domains?
-    var context = CountryData()
-    var readme: String?
+
+  // MARK: Public
+
+  public var getCountryName: String? {
+    context.getCountryName(country ?? "")
+  }
+
+  public var isEU: Bool? {
+    context.isEU(country ?? "")
+  }
+
+  @MainActor
+  public var getCountryFlag: CountryFlag? {
+    context.getCountryFlag(country ?? "")
+  }
+
+  public var getCountryFlagURL: String? {
+    context.getCountryFlagURL(country ?? "")
+  }
+
+  @MainActor
+  public var getCountryCurrency: CountryCurrency? {
+    context.getCountryCurrency(country ?? "")
+  }
+
+  @MainActor
+  public var getContinent: CountryContinent? {
+    context.getContinent(country ?? "")
+  }
+
+  public var getLatitude: String? {
+    loc?.components(separatedBy: ",")[safe: 0]
+  }
+
+  public var getLongitude: String? {
+    loc?.components(separatedBy: ",")[safe: 1]
+  }
+
+  // MARK: Internal
+
+  enum CodingKeys: String, CodingKey {
+    case ip
+    case hostname
+    case bogon
+    case anycast
+    case isAnycast
+    case city
+    case region
+    case country
+    case loc
+    case org
+    case postal
+    case timezone
+    case asn
+    case company
+    case carrier
+    case privacy
+    case abuse
+    case domains
+  }
+
+  let ip: String?
+  let hostname: String?
+  let bogon: Bool?
+  let anycast: Bool?
+  let city: String?
+  let region: String?
+  let country: String?
+  let loc: String?
+  let org: String?
+  let postal: String?
+  let timezone: String?
+  let asn: ASN?
+  let company: Company?
+  let carrier: Carrier?
+  let privacy: Privacy?
+  let abuse: Abuse?
+  let domains: Domains?
+  var context = CountryData()
+  var readme: String?
+
+  public init(from decoder: any Decoder) throws {
+    let container: KeyedDecodingContainer<IPResponse.CodingKeys> = try decoder.container(keyedBy: IPResponse.CodingKeys.self)
+
+    self.ip = try container.decodeIfPresent(String.self, forKey: IPResponse.CodingKeys.ip)
+    self.hostname = try container.decodeIfPresent(String.self, forKey: IPResponse.CodingKeys.hostname)
+    self.bogon = try container.decodeIfPresent(Bool.self, forKey: IPResponse.CodingKeys.bogon)
+    self.anycast = try container
+      .decodeIfPresent(Bool.self, forKey: IPResponse.CodingKeys.anycast) ?? container
+      .decodeIfPresent(Bool.self, forKey: IPResponse.CodingKeys.isAnycast)
+    self.city = try container.decodeIfPresent(String.self, forKey: IPResponse.CodingKeys.city)
+    self.region = try container.decodeIfPresent(String.self, forKey: IPResponse.CodingKeys.region)
+    self.country = try container.decodeIfPresent(String.self, forKey: IPResponse.CodingKeys.country)
+    self.loc = try container.decodeIfPresent(String.self, forKey: IPResponse.CodingKeys.loc)
+    self.org = try container.decodeIfPresent(String.self, forKey: IPResponse.CodingKeys.org)
+    self.postal = try container.decodeIfPresent(String.self, forKey: IPResponse.CodingKeys.postal)
+    self.timezone = try container.decodeIfPresent(String.self, forKey: IPResponse.CodingKeys.timezone)
+    self.asn = try container.decodeIfPresent(ASN.self, forKey: IPResponse.CodingKeys.asn)
+    self.company = try container.decodeIfPresent(Company.self, forKey: IPResponse.CodingKeys.company)
+    self.carrier = try container.decodeIfPresent(Carrier.self, forKey: IPResponse.CodingKeys.carrier)
+    self.privacy = try container.decodeIfPresent(Privacy.self, forKey: IPResponse.CodingKeys.privacy)
+    self.abuse = try container.decodeIfPresent(Abuse.self, forKey: IPResponse.CodingKeys.abuse)
+    self.domains = try container.decodeIfPresent(Domains.self, forKey: IPResponse.CodingKeys.domains)
+
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container: KeyedEncodingContainer<IPResponse.CodingKeys> = encoder.container(keyedBy: IPResponse.CodingKeys.self)
+
+    try container.encodeIfPresent(self.ip, forKey: IPResponse.CodingKeys.ip)
+    try container.encodeIfPresent(self.hostname, forKey: IPResponse.CodingKeys.hostname)
+    try container.encodeIfPresent(self.bogon, forKey: IPResponse.CodingKeys.bogon)
+    try container.encodeIfPresent(self.anycast, forKey: IPResponse.CodingKeys.anycast)
+    try container.encodeIfPresent(self.city, forKey: IPResponse.CodingKeys.city)
+    try container.encodeIfPresent(self.region, forKey: IPResponse.CodingKeys.region)
+    try container.encodeIfPresent(self.country, forKey: IPResponse.CodingKeys.country)
+    try container.encodeIfPresent(self.loc, forKey: IPResponse.CodingKeys.loc)
+    try container.encodeIfPresent(self.org, forKey: IPResponse.CodingKeys.org)
+    try container.encodeIfPresent(self.postal, forKey: IPResponse.CodingKeys.postal)
+    try container.encodeIfPresent(self.timezone, forKey: IPResponse.CodingKeys.timezone)
+    try container.encodeIfPresent(self.asn, forKey: IPResponse.CodingKeys.asn)
+    try container.encodeIfPresent(self.company, forKey: IPResponse.CodingKeys.company)
+    try container.encodeIfPresent(self.carrier, forKey: IPResponse.CodingKeys.carrier)
+    try container.encodeIfPresent(self.privacy, forKey: IPResponse.CodingKeys.privacy)
+    try container.encodeIfPresent(self.abuse, forKey: IPResponse.CodingKeys.abuse)
+    try container.encodeIfPresent(self.domains, forKey: IPResponse.CodingKeys.domains)
+  }
 }

--- a/Sources/ipinfoKit/Model/IPResponse/IPResponse.swift
+++ b/Sources/ipinfoKit/Model/IPResponse/IPResponse.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public struct IPResponse: Codable {
+public struct IPResponse: Codable, Sendable {
     
     // MARK: Lifecycle
     
@@ -57,6 +57,7 @@ public struct IPResponse: Codable {
         context.isEU(country ?? "")
     }
     
+    @MainActor
     public var getCountryFlag: CountryFlag? {
         context.getCountryFlag(country ?? "")
     }
@@ -65,10 +66,12 @@ public struct IPResponse: Codable {
         context.getCountryFlagURL(country ?? "")
     }
     
+    @MainActor
     public var getCountryCurrency: CountryCurrency? {
         context.getCountryCurrency(country ?? "")
     }
     
+    @MainActor
     public var getContinent: CountryContinent? {
         context.getContinent(country ?? "")
     }

--- a/Sources/ipinfoKit/Model/Privacy/Privacy.swift
+++ b/Sources/ipinfoKit/Model/Privacy/Privacy.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-public class Privacy: Codable {
+public struct Privacy: Codable, Sendable {
     
     // MARK: Lifecycle
     

--- a/Sources/ipinfoKit/Utility/Bundle + Extension.swift
+++ b/Sources/ipinfoKit/Utility/Bundle + Extension.swift
@@ -9,7 +9,7 @@ import Foundation
 extension Bundle {
     /// Fetching Api Key from Info.plist
     var accessToken: String? {
-        object(forInfoDictionaryKey: "IPInfoKitAccessToken") as? String
+      return object(forInfoDictionaryKey: "IPInfoKitAccessToken") as? String
     }
     
     /// Fetching App Version from Info.plist

--- a/Sources/ipinfoKit/ipinfoKit.swift
+++ b/Sources/ipinfoKit/ipinfoKit.swift
@@ -7,9 +7,8 @@
 import Foundation
 import Network
 
+@MainActor
 open class IPINFO {
-    
-    // MARK:  Variables
-    public static let `shared` = IPINFO()
-    
+  // MARK:  Variables
+  public static let `shared` = IPINFO()
 }

--- a/Tests/ipinfoKitTests/IPInfoLiteTests.swift
+++ b/Tests/ipinfoKitTests/IPInfoLiteTests.swift
@@ -3,6 +3,7 @@ import ipinfoKit
 import Foundation
 import Testing
 
+@MainActor
 struct IPInfoLiteTests {
     @Test func liteCloudflareDNSTest() async throws {
       let client = IPInfoLite(token: ProcessInfo.processInfo.environment["IPInfoKitAccessToken"] ?? "")

--- a/Tests/ipinfoKitTests/IPInfoLiteTests.swift
+++ b/Tests/ipinfoKitTests/IPInfoLiteTests.swift
@@ -10,15 +10,17 @@ struct IPInfoLiteTests {
       let response = try await client.lookup(ip: "1.1.1.1")
 
       #expect(
-        response == IPInfoLite.Response(
-          ip: "1.1.1.1",
-          asn: "AS13335",
-          asName: "Cloudflare, Inc.",
-          asDomain: "cloudflare.com",
-          countryCode: "AU",
-          country: "Australia",
-          continentCode: "OC",
-          continent: "Oceania"
+        response == .ip(
+          .init(
+            ip: "1.1.1.1",
+            asn: "AS13335",
+            asName: "Cloudflare, Inc.",
+            asDomain: "cloudflare.com",
+            countryCode: "AU",
+            country: "Australia",
+            continentCode: "OC",
+            continent: "Oceania"
+          )
         )
       )
     }
@@ -28,17 +30,6 @@ struct IPInfoLiteTests {
 
     let response = try await client.lookup(ip: "192.168.1.1")
 
-    #expect(
-      response == IPInfoLite.Response(
-        ip: "1.1.1.1",
-        asn: "AS13335",
-        asName: "Cloudflare, Inc.",
-        asDomain: "cloudflare.com",
-        countryCode: "AU",
-        country: "Australia",
-        continentCode: "OC",
-        continent: "Oceania"
-      )
-    )
+    #expect(response == .bogon(.init(ip: "192.168.1.1")))
   }
 }

--- a/Tests/ipinfoKitTests/IPInfoLiteTests.swift
+++ b/Tests/ipinfoKitTests/IPInfoLiteTests.swift
@@ -1,0 +1,44 @@
+import ipinfoKit
+
+import Foundation
+import Testing
+
+struct IPInfoLiteTests {
+    @Test func liteCloudflareDNSTest() async throws {
+      let client = IPInfoLite(token: ProcessInfo.processInfo.environment["IPInfoKitAccessToken"] ?? "")
+
+      let response = try await client.lookup(ip: "1.1.1.1")
+
+      #expect(
+        response == IPInfoLite.Response(
+          ip: "1.1.1.1",
+          asn: "AS13335",
+          asName: "Cloudflare, Inc.",
+          asDomain: "cloudflare.com",
+          countryCode: "AU",
+          country: "Australia",
+          continentCode: "OC",
+          continent: "Oceania"
+        )
+      )
+    }
+
+  @Test func liteBogonTest() async throws {
+    let client = IPInfoLite(token: ProcessInfo.processInfo.environment["IPInfoKitAccessToken"] ?? "")
+
+    let response = try await client.lookup(ip: "192.168.1.1")
+
+    #expect(
+      response == IPInfoLite.Response(
+        ip: "1.1.1.1",
+        asn: "AS13335",
+        asName: "Cloudflare, Inc.",
+        asDomain: "cloudflare.com",
+        countryCode: "AU",
+        country: "Australia",
+        continentCode: "OC",
+        continent: "Oceania"
+      )
+    )
+  }
+}

--- a/Tests/ipinfoKitTests/ipinfoKitTests.swift
+++ b/Tests/ipinfoKitTests/ipinfoKitTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import ipinfoKit
 
+@MainActor
 final class ipinfoKitTests: XCTestCase {
     func testIPResponseInitialization() {
         let expectation = expectation(description: "IP details request")

--- a/Tests/ipinfoKitTests/ipinfoKitTests.swift
+++ b/Tests/ipinfoKitTests/ipinfoKitTests.swift
@@ -27,13 +27,6 @@ final class ipinfoKitTests: XCTestCase {
                 XCTAssertEqual(response.getContinent?.code, "NA")
                 XCTAssertEqual(response.getContinent?.name, "North America")
                 XCTAssertEqual(response.timezone, "America/Los_Angeles")
-                XCTAssertFalse(response.privacy?.proxy ?? true)
-                XCTAssertFalse(response.privacy?.vpn ?? true)
-                XCTAssertFalse(response.privacy?.tor ?? true)
-                XCTAssertFalse(response.privacy?.relay ?? true)
-                XCTAssertTrue(response.privacy?.hosting ?? false)
-                XCTAssertEqual(response.privacy?.service, "")
-                XCTAssertEqual(response.domains?.domains.count, 5)
             case .failure:
                 XCTFail(msg ?? "Error")
             }

--- a/Tests/ipinfoKitTests/ipinfoKitTests.swift
+++ b/Tests/ipinfoKitTests/ipinfoKitTests.swift
@@ -14,8 +14,7 @@ final class ipinfoKitTests: XCTestCase {
                 XCTAssertNotNil(response, "Response is nil")
                 XCTAssertEqual(response.ip, "8.8.8.8")
                 XCTAssertEqual(response.hostname, "dns.google")
-                // fails on CI
-//                XCTAssertTrue(response.anycast ?? false)
+                XCTAssertTrue(response.anycast ?? false)
                 XCTAssertEqual(response.city, "Mountain View")
                 XCTAssertEqual(response.region, "California")
                 XCTAssertEqual(response.country, "US")

--- a/Tests/ipinfoKitTests/ipinfoKitTests.swift
+++ b/Tests/ipinfoKitTests/ipinfoKitTests.swift
@@ -14,7 +14,8 @@ final class ipinfoKitTests: XCTestCase {
                 XCTAssertNotNil(response, "Response is nil")
                 XCTAssertEqual(response.ip, "8.8.8.8")
                 XCTAssertEqual(response.hostname, "dns.google")
-                XCTAssertTrue(response.anycast ?? false)
+                // fails on CI
+//                XCTAssertTrue(response.anycast ?? false)
                 XCTAssertEqual(response.city, "Mountain View")
                 XCTAssertEqual(response.region, "California")
                 XCTAssertEqual(response.country, "US")


### PR DESCRIPTION
Add support for the Lite API and make the original tests pass by providing a token as an environment variable and removing fields no longer returned.

Fixes #8 