### PR TITLE
Avoid Sendable data-race diagnostic in API completion

### DIFF
--- a/Sources/ipinfoKit/API/API.swift
+++ b/Sources/ipinfoKit/API/API.swift
@@ -61,20 +61,16 @@ public class Service {
         URL: Service.Router,
         method: HTTPMethod,
         params: Parameters? = nil,
-        completion: @escaping (_ status: Response,_ data: Data,_ msg: String) -> Void) {
-            
-            let requestSession = session ?? AF
-            requestSession.request(URL.endPoint , method: method, parameters: params , encoding: JSONEncoding.default, headers: headers)
-                .response { response in
-                    DispatchQueue.main.async {
-                        switch response.result {
-                        case .success(let value):
-                            completion(.success, value ?? Data(), "Success")
-                        case .failure(let err):
-                            completion(.failure, Data(), err.localizedDescription)
-                            break
-                        }
-                    }
+        completion: @escaping (_ status: Response, _ data: Data, _ msg: String) -> Void) {
+        let requestSession = session ?? AF
+        requestSession.request(URL.endPoint, method: method, parameters: params, encoding: JSONEncoding.default, headers: headers)
+            .response(queue: .main) { response in
+                switch response.result {
+                case .success(let value):
+                    completion(.success, value ?? Data(), "Success")
+                case .failure(let err):
+                    completion(.failure, Data(), err.localizedDescription)
                 }
-        }
+            }
+    }
 }


### PR DESCRIPTION
## Summary
- run Alamofire response handler on `.main` queue directly
- remove nested `DispatchQueue.main.async` around `completion`
- keep API behavior unchanged while avoiding Swift 6 sendability/data-race diagnostics

## Context
Xcode/Swift 6 strict concurrency can report:
`Sending 'completion' risks causing data races` in `Service.requestAPI`.

This patch keeps callback delivery on the main thread via Alamofire's response queue and avoids capturing `completion` in an extra sendable closure.